### PR TITLE
Fix execution order

### DIFF
--- a/src/XFrameOptions.php
+++ b/src/XFrameOptions.php
@@ -37,12 +37,13 @@ class XFrameOptions
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next)
     {
+        $response = $next($request, $response);
+
         if ($response->hasHeader(self::X_FRAME_OPTIONS)) {
-            return $response = $next($request, $response);
+            return $response;
         }
 
-        $response = $response->withAddedHeader(self::X_FRAME_OPTIONS, $this->getXFrameOption());
-        return $response = $next($request, $response);
+        return $response->withAddedHeader(self::X_FRAME_OPTIONS, $this->getXFrameOption());
     }
 
 

--- a/tests/XFrameOptionsTest.php
+++ b/tests/XFrameOptionsTest.php
@@ -27,7 +27,7 @@ class XFrameOptionsTest extends \PHPUnit_Framework_TestCase
         $response = new Response();
 
         /** @var Response $response */
-        $response = $middleware($request, $response, function($request, $response){
+        $response = $middleware($request, $response, function ($request, $response) {
             return $response;
         });
 
@@ -42,10 +42,25 @@ class XFrameOptionsTest extends \PHPUnit_Framework_TestCase
         $response = $response->withAddedHeader(XFrameOptions::X_FRAME_OPTIONS, 'abc');
 
         /** @var Response $response */
-        $response = $middleware($request, $response, function($request, $response){
+        $response = $middleware($request, $response, function ($request, $response) {
             return $response;
         });
 
         $this->assertSame(['abc'], $response->getHeader(XFrameOptions::X_FRAME_OPTIONS));
+    }
+
+
+    public function testMiddlewareFunctionalityNewResponse()
+    {
+        $middleware = new XFrameOptions();
+        $request = ServerRequestFactory::fromGlobals();
+        $response = new Response();
+
+        /** @var Response $response */
+        $response = $middleware($request, $response, function ($request, $response) {
+            return new Response();
+        });
+
+        $this->assertSame([XFrameOptions::SAMEORIGIN], $response->getHeader(XFrameOptions::X_FRAME_OPTIONS));
     }
 }

--- a/tests/XFrameOptionsTest.php
+++ b/tests/XFrameOptionsTest.php
@@ -17,7 +17,7 @@ class XFrameOptionsTest extends \PHPUnit_Framework_TestCase
     public function testWithPassedParamToConstructor()
     {
         $xFrameOption = new XFrameOptions(XFrameOptions::DENY);
-        $this->assertEquals(XFrameOptions::DENY, $xFrameOption->getXFrameOption());
+        $this->assertSame(XFrameOptions::DENY, $xFrameOption->getXFrameOption());
     }
 
     public function testMiddlewareFunctionalityWithoutXframeOptionsHeader()
@@ -31,7 +31,7 @@ class XFrameOptionsTest extends \PHPUnit_Framework_TestCase
             return $response;
         });
 
-        $this->assertEquals($response->getHeader(XFrameOptions::X_FRAME_OPTIONS)[0], XFrameOptions::SAMEORIGIN);
+        $this->assertSame([XFrameOptions::SAMEORIGIN], $response->getHeader(XFrameOptions::X_FRAME_OPTIONS));
     }
 
     public function testMiddlewareFunctionalityWithXFrameOptionsHeader()
@@ -46,6 +46,6 @@ class XFrameOptionsTest extends \PHPUnit_Framework_TestCase
             return $response;
         });
 
-        $this->assertEquals($response->getHeader(XFrameOptions::X_FRAME_OPTIONS)[0], 'abc');
+        $this->assertSame(['abc'], $response->getHeader(XFrameOptions::X_FRAME_OPTIONS));
     }
 }


### PR DESCRIPTION
The current implementation lacks support for some valid use cases:

``` php
$app->get('/gone', function ($request, $response) {
    return new Custom410Response();
});
```

This PR fixes the [execution order](http://www.slimframework.com/docs/concepts/middleware.html#how-does-middleware-work) and some minor test issues.
