### PR TITLE
Revert "overwrite header"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Clickjacking Protection Middleware
 PSR-7 Middleware that provides clickjacking protection via the X-Frame-Options header.
 
-Middleware that sets the X-Frame-Options HTTP header in HTTP responses.
+Middleware that sets the X-Frame-Options HTTP header in HTTP responses. Does not set the header if it's already set.
 By default, sets the X-Frame-Options header to 'SAMEORIGIN', meaning the response can only be loaded on a frame within the same site.
 
 Note: older browsers will quietly ignore this header, thus other clickjacking protection techniques should be used if protection in those browsers is required.

--- a/src/XFrameOptions.php
+++ b/src/XFrameOptions.php
@@ -25,6 +25,7 @@ class XFrameOptions
 
     /**
      *  Middleware that sets the X-Frame-Options HTTP header in HTTP responses.
+     *  Does not set the header if it's already set.
      *  By default, sets the X-Frame-Options header to 'SAMEORIGIN', meaning the
      *  response can only be loaded on a frame within the same site.
      *
@@ -36,7 +37,13 @@ class XFrameOptions
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next)
     {
-        return $next($request, $response)->withHeader(self::X_FRAME_OPTIONS, $this->getXFrameOption());
+        $response = $next($request, $response);
+
+        if ($response->hasHeader(self::X_FRAME_OPTIONS)) {
+            return $response;
+        }
+
+        return $response->withAddedHeader(self::X_FRAME_OPTIONS, $this->getXFrameOption());
     }
 
 

--- a/tests/XFrameOptionsTest.php
+++ b/tests/XFrameOptionsTest.php
@@ -39,14 +39,16 @@ class XFrameOptionsTest extends \PHPUnit_Framework_TestCase
         $middleware = new XFrameOptions();
         $request = ServerRequestFactory::fromGlobals();
         $response = new Response();
+        $response = $response->withAddedHeader(XFrameOptions::X_FRAME_OPTIONS, 'abc');
 
         /** @var Response $response */
         $response = $middleware($request, $response, function ($request, $response) {
-            return $response->withHeader(XFrameOptions::X_FRAME_OPTIONS, XFrameOptions::DENY);
+            return $response;
         });
 
-        $this->assertSame([XFrameOptions::SAMEORIGIN], $response->getHeader(XFrameOptions::X_FRAME_OPTIONS));
+        $this->assertSame(['abc'], $response->getHeader(XFrameOptions::X_FRAME_OPTIONS));
     }
+
 
     public function testMiddlewareFunctionalityNewResponse()
     {


### PR DESCRIPTION
#1 has changed the execution order of further middlewares (`$next`).

Thus, the following has already worked as expected since #1:

``` php
$app->group('/foo', function () {
    $this->get('/bar', function ($request, $response) {
    // ...
    })->add(new XFrameOptions('SAMEORIGIN'));

    $this->get('/bar2', function ($request, $response) {
    // ...
    });
})->add(new XFrameOptions('DENY'));
```

Therefore, #3 has reintroduced the behavior it was meant to fix…
